### PR TITLE
Separate prefix with a hyphen or underscore

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -1,5 +1,5 @@
 {
-        hostname_prefix = 'ffs',
+        hostname_prefix = 'ffs-',
         site_name = 'Freifunk Stuttgart',
         site_code = 'ffs',
 


### PR DESCRIPTION
According to https://wiki.freifunk-stuttgart.net/technik:administration:knotenid it should start with 'ffs-'
Is this still a problem? https://github.com/freifunk-gluon/gluon/issues/507
