### PR TITLE
Gluon ssid changer

### DIFF
--- a/modules
+++ b/modules
@@ -1,0 +1,3 @@
+GLUON_SITE_FEEDS="ssidchanger"
+PACKAGES_SSIDCHANGER_REPO=https://github.com/ffac/gluon-ssid-changer.git
+PACKAGES_SSIDCHANGER_COMMIT=06bdf6fc6149af9cbb4564aac82cadd56a98a8b2

--- a/site.conf
+++ b/site.conf
@@ -4,8 +4,8 @@
         site_code = 'ffs',
 	
 	opkg = {
-		openwrt = 'http://[fd21:b4dc:4b1e::a38:1]/openwrt/barrier_breaker/14.07/%S/packages',
-		},
+		openwrt = 'http://[fd21:b4dc:4b1e::a38:1]/openwrt/%n/%v/%S/packages',
+	},
 	
 	prefix4 = '172.21.0.0/18',
         prefix6 = 'fd21:b4dc:4b1e::/64',

--- a/site.mk
+++ b/site.mk
@@ -122,6 +122,23 @@ TOOLS_PACKAGES := \
 # $(GLUON_TARGET) specific settings:
 #
 
+# add offline ssid only if the target has wifi device
+
+ifeq ($(GLUON_TARGET),ar71xx-generic)
+GLUON_SITE_PACKAGES += \
+        gluon-ssid-changer
+endif
+
+ifeq ($(GLUON_TARGET),ar71xx-nand)
+GLUON_SITE_PACKAGES += \
+        gluon-ssid-changer
+endif
+
+ifeq ($(GLUON_TARGET),mpc85xx-generic)
+GLUON_SITE_PACKAGES += \
+        gluon-ssid-changer
+endif
+
 # x86-generic
 ifeq ($(GLUON_TARGET),x86-generic)
 # support the usb stack on x86 devices
@@ -136,7 +153,7 @@ GLUON_SITE_PACKAGES += \
 	$(TOOLS_PACKAGES)
 endif
 
-#ar71xx-generic
+# ar71xx-generic
 GLUON_TLWR842_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 GLUON_TLWR1043_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 GLUON_TLWR2543_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
@@ -148,8 +165,9 @@ GLUON_GLINET_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACK
 GLUON_WZRHPG450H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 
-#mpc85xx-generic
+# mpc85xx-generic
 GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
 
 #
 # General settings

--- a/site.mk
+++ b/site.mk
@@ -1,3 +1,8 @@
+#
+# GLUON_SITE_PACKAGES modular definition
+#
+
+# base packages
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-15 \
 	gluon-alfred \
@@ -26,13 +31,137 @@ GLUON_SITE_PACKAGES := \
 	iptables \
 	iwinfo
 
+# basic support for USB stack
+USB_PACKAGES_BASIC := \
+	kmod-usb-core \
+	kmod-usb2
 
-DEFAULT_GLUON_RELEASE := 0.6-g.$(shell git -C $(GLUONDIR) log --pretty=format:'%h' -n 1)-s.$(shell git -C $(GLUONDIR)/site log --pretty=format:'%h' -n 1)
+# storage support for USB devices
+USB_PACKAGES_STORAGE := \
+	block-mount \
+	blkid \
+	kmod-fs-ext4 \
+	kmod-fs-vfat \
+	kmod-usb-storage \
+	kmod-usb-storage-extras \
+	kmod-nls-cp1250 \
+	kmod-nls-cp1251 \
+	kmod-nls-cp437 \
+	kmod-nls-cp775 \
+	kmod-nls-cp850 \
+	kmod-nls-cp852 \
+	kmod-nls-cp866 \
+	kmod-nls-iso8859-1 \
+	kmod-nls-iso8859-13 \
+	kmod-nls-iso8859-15 \
+	kmod-nls-iso8859-2 \
+	kmod-nls-koi8r \
+	kmod-nls-utf8 \
+	swap-utils
 
-GLUON_LANGS := de en
+# network support for USB devices
+USB_PACKAGES_NET := \
+	kmod-mii \
+	kmod-nls-base \
+	kmod-usb-net \
+	kmod-usb-net-asix \
+	kmod-usb-net-asix-ax88179 \
+	kmod-usb-net-cdc-eem \
+	kmod-usb-net-cdc-ether \
+	kmod-usb-net-cdc-mbim \
+	kmod-usb-net-cdc-ncm \
+	kmod-usb-net-cdc-subset \
+	kmod-usb-net-dm9601-ether \
+	kmod-usb-net-hso \
+	kmod-usb-net-huawei-cdc-ncm
+	kmod-usb-net-ipheth \
+	kmod-usb-net-kalmia \
+	kmod-usb-net-kaweth \
+	kmod-usb-net-mcs7830 \
+	kmod-usb-net-pegasus \
+	kmod-usb-net-qmi-wwan \
+	kmod-usb-net-rndis \
+	kmod-usb-net-sierrawireless \
+	kmod-usb-net-smsc95xx
+# broken
+#	kmod-usb-net-rtl8150 \
+#	kmod-usb-net-rtl8152 \
+
+# network support for PCI devices
+PCI_PACKAGES_NET := \
+	kmod-3c59x \
+	kmod-e100 \
+	kmod-e1000 \
+	kmod-e1000e \
+	kmod-forcedeth \
+	kmod-natsemi \
+	kmod-ne2k-pci \
+	kmod-pcnet32 \
+	kmod-r8139too \
+	kmod-r8169 \
+	kmod-sis900 \
+	kmod-sky2 \
+	kmod-tg3 \
+	kmod-tulip \
+	kmod-via-rhine
+# broken
+#	kmod-ixgbe \
+
+# additional packages
+TOOLS_PACKAGES := \
+	iperf \
+	socat \
+	tcpdump \
+	usbutils \
+	vnstat
+# broken
+#	pciutils \
+
+
+#
+# $(GLUON_TARGET) specific settings:
+#
+
+# x86-generic
+ifeq ($(GLUON_TARGET),x86-generic)
+# support the usb stack on x86 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES)
+endif
+
+#ar71xx-generic
+GLUON_TLWR842_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR1043_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR2543_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWDR4300_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WNDR3700_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WRT160NL_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_ARCHERC7_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_GLINET_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPG450H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+#mpc85xx-generic
+GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+#
+# General settings
+#
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 
+DEFAULT_GLUON_RELEASE := 0.6-g.$(shell git -C $(GLUONDIR) log --pretty=format:'%h' -n 1)-s.$(shell git -C $(GLUONDIR)/site log --pretty=format:'%h' -n 1)
+
 # Default priority for updates.
 GLUON_PRIORITY ?= 0.1
+
+# Languages to include
+GLUON_LANGS ?= de en

--- a/site.mk
+++ b/site.mk
@@ -97,7 +97,6 @@ PCI_PACKAGES_NET := \
 	kmod-natsemi \
 	kmod-ne2k-pci \
 	kmod-pcnet32 \
-	kmod-r8139too \
 	kmod-r8169 \
 	kmod-sis900 \
 	kmod-sky2 \
@@ -106,6 +105,7 @@ PCI_PACKAGES_NET := \
 	kmod-via-rhine
 # broken
 #	kmod-ixgbe \
+#	kmod-r8139too \
 
 # additional packages
 TOOLS_PACKAGES := \

--- a/site.mk
+++ b/site.mk
@@ -73,7 +73,7 @@ USB_PACKAGES_NET := \
 	kmod-usb-net-cdc-subset \
 	kmod-usb-net-dm9601-ether \
 	kmod-usb-net-hso \
-	kmod-usb-net-huawei-cdc-ncm
+	kmod-usb-net-huawei-cdc-ncm \
 	kmod-usb-net-ipheth \
 	kmod-usb-net-kalmia \
 	kmod-usb-net-kaweth \


### PR DESCRIPTION
This enables ffac/gluon-ssid-changer@06bdf6f on devices with WiFI.

Is this feature desired by Freifunk-Stuttgart?
