### PR TITLE
New IPv6 prefix and next_node address

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,7 +8,7 @@
     },
     
     prefix4 = '172.21.0.0/18',
-    prefix6 = 'fd21:b4dc:4b1e::/64',
+    prefix6 = 'fd21:711::/64',
         
     timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
         
@@ -47,7 +47,7 @@
 
     next_node = {
                 ip4 = '172.21.24.254',
-                ip6 = 'fd21:b4dc:4b1e::1',
+                ip6 = 'fd21:711::1',
                 mac = '02:00:0a:25:00:01',
     },
 
@@ -223,7 +223,7 @@
                 good_signatures = 2,
                 pubkeys = {
                     '4418436fe872b5746a6c86293afca7c6c9edba03eca3cac80fdfd82106092d7a', -- leonard
-                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are    
+                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are
                     'b7077095e9d3fc892db1c280b78b65d737700c9aea70a6998d6aad8b3146aaed', -- flip
                 },
             },
@@ -235,7 +235,7 @@
                 good_signatures = 1,
                 pubkeys = {
                     '4418436fe872b5746a6c86293afca7c6c9edba03eca3cac80fdfd82106092d7a', -- leonard
-                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are    
+                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are
                     'b7077095e9d3fc892db1c280b78b65d737700c9aea70a6998d6aad8b3146aaed', -- flip
                 },
             },
@@ -247,7 +247,7 @@
                 good_signatures = 1,
                 pubkeys = {
                     '4418436fe872b5746a6c86293afca7c6c9edba03eca3cac80fdfd82106092d7a', -- leonard
-                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are    
+                    '0b43680e4c389a55a02663a740be234defe017c1e05ba49de87baaa1f88c66c1', -- are
                     'b7077095e9d3fc892db1c280b78b65d737700c9aea70a6998d6aad8b3146aaed', -- flip
                 },
             },

--- a/site.conf
+++ b/site.conf
@@ -4,7 +4,7 @@
     site_code = 'ffs',
     
     opkg = {
-        openwrt = 'http://[fd21:b4dc:4b00::a38:1]/openwrt/barrier_breaker/14.07/%S/packages',
+        openwrt = 'http://[fd21:b4dc:4b00::a38:1]/openwrt/%n/%v/%S/packages',
     },
     
     prefix4 = '172.21.0.0/18',


### PR DESCRIPTION
As of today, the IPv4 next_node address isn't easily accessible. 
There are considerations to save the IPv4 next_node address in freifunk-gluon/gluon#618.
