### PR TITLE
don't enable bandwidth limit by default

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -202,6 +202,8 @@
     },
     
     bandwidth_limit = {
+        -- enable it by default or not
+        enabled = false,
         -- Default upload limit (kbit/s).
         egress = 500,
         -- Default download limit (kbit/s).


### PR DESCRIPTION
the definition was missing. I am not sure what is the default, if this is not set.

Do you want to have this enabled by default in Stuttgart?
