### PR TITLE
Option to override build date

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -59,7 +59,11 @@ GLUON_SITE_PACKAGES += \
 	kmod-igb
 endif
 
-DEFAULT_GLUON_RELEASE := 1.4+$(shell date '+%Y-%m-%d')-g.$(shell git -C $(GLUON_SITEDIR)/../ log --pretty=format:'%h' -n 1)-s.$(shell git -C $(GLUON_SITEDIR) log --pretty=format:'%h' -n 1)
+DEFAULT_BUILD_DATE := $(shell date '+%Y-%m-%d')
+
+BUILD_DATE ?= $(DEFAULT_BUILD_DATE)
+
+DEFAULT_GLUON_RELEASE := 1.4+$(BUILD_DATE)-g.$(shell git -C $(GLUON_SITEDIR)/../ log --pretty=format:'%h' -n 1)-s.$(shell git -C $(GLUON_SITEDIR) log --pretty=format:'%h' -n 1)
 
 GLUON_LANGS := de en
 


### PR DESCRIPTION
Setting BUILD_DATE overrides the date used in the generated image names.
With this it is possible to have a consistent build date across all
architectures, making it easier to identify a release. Furthre more it
might be the key to have reproducible builds